### PR TITLE
Add postID:Int to Post, format files to follow kotlin style guide, ad…

### DIFF
--- a/UniConnectApp/app/src/main/AndroidManifest.xml
+++ b/UniConnectApp/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.uniconnect">
 
+    <uses-permission android:name="android.permission.INTERNET"/>
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/UniConnectApp/app/src/main/java/com/example/uniconnect/MainActivity.kt
+++ b/UniConnectApp/app/src/main/java/com/example/uniconnect/MainActivity.kt
@@ -18,7 +18,10 @@ class MainActivity : ComponentActivity() {
         setContent {
             UniConnectTheme {
                 // A surface container using the 'background' color from the theme
-                Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colors.background) {
+                Surface(
+                    modifier = Modifier.fillMaxSize(),
+                    color = MaterialTheme.colors.background
+                ) {
                     Greeting("Android")
                 }
             }

--- a/UniConnectApp/app/src/main/java/com/example/uniconnect/RetrofitClientInstance.kt
+++ b/UniConnectApp/app/src/main/java/com/example/uniconnect/RetrofitClientInstance.kt
@@ -7,7 +7,7 @@ object RetrofitClientInstance {
     private var retrofit: Retrofit? = null
     private val BASE_URL = "http://universities.hipolabs.com/"
 
-    val retrofitInstance : Retrofit?
+    val retrofitInstance: Retrofit?
         get() {
             // has this object been created yet?
             if (retrofit == null) {

--- a/UniConnectApp/app/src/main/java/com/example/uniconnect/dao/IUniversityDAO.kt
+++ b/UniConnectApp/app/src/main/java/com/example/uniconnect/dao/IUniversityDAO.kt
@@ -11,5 +11,5 @@ interface IUniversityDAO {
      * @return List of universities
      */
     @GET("/search")
-    fun getAllUniversities() : Call<ArrayList<University>>
+    fun getAllUniversities(): Call<ArrayList<University>>
 }

--- a/UniConnectApp/app/src/main/java/com/example/uniconnect/dto/Post.kt
+++ b/UniConnectApp/app/src/main/java/com/example/uniconnect/dto/Post.kt
@@ -1,6 +1,6 @@
 package com.example.uniconnect.dto
 
-data class Post(var title: String, var description: String) {
+data class Post(var postID: Int, var title: String, var description: String) {
     override fun toString(): String {
         return "$title - $description"
     }

--- a/UniConnectApp/app/src/main/java/com/example/uniconnect/dto/University.kt
+++ b/UniConnectApp/app/src/main/java/com/example/uniconnect/dto/University.kt
@@ -2,7 +2,11 @@ package com.example.uniconnect.dto
 
 import com.google.gson.annotations.SerializedName
 
-data class University(@SerializedName("name") var name: String, @SerializedName("country")var country: String, @SerializedName("alpha_two_code") var code: String) {
+data class University(
+    @SerializedName("name") var name: String,
+    @SerializedName("country") var country: String,
+    @SerializedName("alpha_two_code") var code: String
+) {
     override fun toString(): String {
         return "$name - $country - $code"
     }

--- a/UniConnectApp/app/src/main/java/com/example/uniconnect/service/UniversityService.kt
+++ b/UniConnectApp/app/src/main/java/com/example/uniconnect/service/UniversityService.kt
@@ -11,8 +11,9 @@ import retrofit2.awaitResponse
 class UniversityService : IUniversityService {
     override suspend fun fetchUniversities(): List<University>? {
         return withContext(Dispatchers.IO) {
-            val retrofit = RetrofitClientInstance.retrofitInstance?.create(IUniversityDAO::class.java)
-            val universities = async { retrofit?.getAllUniversities()}
+            val retrofit =
+                RetrofitClientInstance.retrofitInstance?.create(IUniversityDAO::class.java)
+            val universities = async { retrofit?.getAllUniversities() }
             val result = universities.await()?.awaitResponse()?.body()
             return@withContext result
         }

--- a/UniConnectApp/app/src/test/java/com/example/uniconnect/UniConnectUnitTest.kt
+++ b/UniConnectApp/app/src/test/java/com/example/uniconnect/UniConnectUnitTest.kt
@@ -36,7 +36,7 @@ class UniConnectUnitTest {
     @get:Rule
     var rule: TestRule = InstantTaskExecutorRule()
     lateinit var universityService: IUniversityService
-    var allUniversities : List<University>? = ArrayList<University>()
+    var allUniversities: List<University>? = ArrayList<University>()
 
     private val mainThreadSurrogate = newSingleThreadContext("UI thread")
 
@@ -52,19 +52,20 @@ class UniConnectUnitTest {
     }
 
     @Test
-    fun `Given a post DTO when title is CCM Concert and description is In Corbet Auditorium `(){
-        val post = Post("CCM Concert", "In Corbet Auditorium")
+    fun `Given a post DTO when title is CCM Concert and description is In Corbet Auditorium `() {
+        val post = Post(1, "CCM Concert", "In Corbet Auditorium")
         assertTrue(post.title.equals("CCM Concert"))
         assertTrue(post.description.equals("In Corbet Auditorium"))
     }
+
     @Test
-    fun `Given a post DTO when  title is CCM Concert and description is In Corbet Auditorium then output is CCM Concert - In Corbet Auditorium`(){
-        val post = Post("CCM Concert", "In Corbet Auditorium")
+    fun `Given a post DTO when  title is CCM Concert and description is In Corbet Auditorium then output is CCM Concert - In Corbet Auditorium`() {
+        val post = Post(1, "CCM Concert", "In Corbet Auditorium")
         assertTrue(post.toString().equals("CCM Concert - In Corbet Auditorium"))
     }
 
     @Test
-    fun `Given a University DTO when name is MaryWood University and country is United States`(){
+    fun `Given a University DTO when name is MaryWood University and country is United States`() {
         val university = University("MaryWood University", "United States", "US")
         assertTrue(university.name.equals("MaryWood University"))
         assertTrue(university.country.equals("United States"))
@@ -73,12 +74,12 @@ class UniConnectUnitTest {
     @Test
     fun `Given service connects to University JSON stream when data are read and parsed then university collection should be greater than zero`() =
         runTest {
-        launch(Dispatchers.Main) {
-            givenUniversityServiceIsInitialized()
-            whenServiceDataAreReadAndParsed()
-            thenTheUniversityCollectionSizeShouldBeGreaterThanZero()
+            launch(Dispatchers.Main) {
+                givenUniversityServiceIsInitialized()
+                whenServiceDataAreReadAndParsed()
+                thenTheUniversityCollectionSizeShouldBeGreaterThanZero()
+            }
         }
-    }
 
     private fun givenUniversityServiceIsInitialized() {
         universityService = UniversityService()
@@ -91,6 +92,13 @@ class UniConnectUnitTest {
     private fun thenTheUniversityCollectionSizeShouldBeGreaterThanZero() {
         assertNotNull(allUniversities)
         assertTrue(allUniversities!!.isNotEmpty())
+        var containsMarywoodUniversity = false
+        allUniversities!!.forEach {
+            if (it.name.equals("Marywood University") && it.code.equals("US")) {
+                containsMarywoodUniversity = true
+            }
+        }
+        assertTrue(containsMarywoodUniversity)
     }
 
     /*@Test


### PR DESCRIPTION
Changes:

Added to a test in the file to verify that an actual result came back instead of just being non-empty
Added postID variable to Post
Formatted several files to fit the kotlin style guide better
Added internet permission to the android manifest

Analysis:
The program looks like it will have various universities and users will be able to view posts by these universities. They have dto for posts and universities, and service to pull university data from the web

It was available on github on time and compiled and ran. It was also documented well enough for me to understand

Rationale for my changes:
I learned during my individual assignment that it is possible to get unexpected results from an API, specifically that I would receive an array full of empty strings, **which is not an empty array**. By checking an actual result it is much more likely to verify that the API was hit properly.

Universities may post often, titles may get re-used. Having a number to identify them makes it far less likely that there will be some conflict 

The internet permission I added was just a formality that will be required for the app in the emulator to work properly

The kotlin style things were done automatically via https://kotlinlang.org/docs/coding-conventions.html#apply-the-style-guide and using alt-shift-enter within android studio